### PR TITLE
fix issues when selection is entire section but filter function expects list

### DIFF
--- a/scripts/sub-digest/subdigest.py
+++ b/scripts/sub-digest/subdigest.py
@@ -117,7 +117,8 @@ class Subtitles:
 
     def _get_selection(self):
         if self.selection is None:
-            return self._get_section()
+            # return copy of section contents as list
+            return [line for line in self._get_section()]
 
         return [line for i, line in enumerate(self._get_section())
                 if i in self.selection]
@@ -130,15 +131,17 @@ class Subtitles:
                 if i not in self.selection]
 
     def _process_selection(self, f):
+        lines = self._get_selection()
+
         if self.selection is None:
-            f(self._get_section())
+            indices = [i for i, line in enumerate(lines)]
         else:
             indices = sorted(self.selection)
-            lines = self._get_selection()
-            f(lines)
-            section = self._get_section()
-            for i, line in zip(indices, lines):
-                section[i] = line
+
+        f(lines)
+        section = self._get_section()
+        for i, line in zip(indices, lines):
+            section[i] = line
 
     @filter
     def use_styles(self) -> Subtitles:

--- a/scripts/sub-digest/subdigest.py
+++ b/scripts/sub-digest/subdigest.py
@@ -118,7 +118,7 @@ class Subtitles:
     def _get_selection(self):
         if self.selection is None:
             # return copy of section contents as list
-            return [line for line in self._get_section()]
+            return list(self._get_section())
 
         return [line for i, line in enumerate(self._get_section())
                 if i in self.selection]

--- a/scripts/sub-digest/subdigest.py
+++ b/scripts/sub-digest/subdigest.py
@@ -134,7 +134,7 @@ class Subtitles:
         lines = self._get_selection()
 
         if self.selection is None:
-            indices = [i for i, line in enumerate(lines)]
+            indices = range(len(lines))
         else:
             indices = sorted(self.selection)
 


### PR DESCRIPTION
Fixes issue with both `sort_field` and `sort_expression`, which are using functionality specific to `list` (others filters might as well). Current version fails to sort without a selection:

```
$ /tmp/subdigest.py -i test.ass --sort-field layer ASC
Traceback (most recent call last):
  File "/tmp/subdigest.py", line 569, in <module>
    sys.exit(main())
  File "/tmp/subdigest.py", line 557, in main
    sub_obj = filt(*filter_args)
  File "/tmp/subdigest.py", line 408, in sort_field
    self._process_selection(_sort)
  File "/tmp/subdigest.py", line 134, in _process_selection
    f(self._get_section())
  File "/tmp/subdigest.py", line 407, in _sort
    events.sort(key=lambda line: getattr(line, field), reverse=order == "DESC")
AttributeError: 'EventsSection' object has no attribute 'sort'
```

Changes:
- `Subtitles._get_selection()`
  - always return a list
- `Subtitles._process_selection()`
  - always call `_get_selection()` for items to process
  - single code path for reinserting changes